### PR TITLE
Verify broker config instead of creating

### DIFF
--- a/announce.gemspec
+++ b/announce.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'growl'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'guard'
+  spec.add_development_dependency 'listen', '~> 3.2.0'
   spec.add_development_dependency 'guard-minitest'
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'simplecov'

--- a/announce.gemspec
+++ b/announce.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'shoryuken'
+  spec.add_development_dependency 'shoryuken', '~> 2.0.5'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'growl'

--- a/lib/announce.rb
+++ b/lib/announce.rb
@@ -21,8 +21,8 @@ module Announce
       adapter_class.subscribe(worker_class, subject, actions, options)
     end
 
-    def configure_broker
-      adapter_class.configure_broker(options)
+    def configure_broker(opts = {})
+      adapter_class.configure_broker(options.merge(opts))
     end
 
     def options

--- a/lib/announce.rb
+++ b/lib/announce.rb
@@ -1,17 +1,16 @@
-require 'logger'
+require "logger"
 
-require 'announce/configuration'
-require 'announce/core_ext'
-require 'announce/message'
-require 'announce/publisher'
-require 'announce/subscriber'
-require 'announce/version'
-require 'announce/railtie' if defined?(Rails)
+require "announce/configuration"
+require "announce/core_ext"
+require "announce/message"
+require "announce/publisher"
+require "announce/subscriber"
+require "announce/version"
+require "announce/railtie" if defined?(Rails)
 
 module Announce
   class << self
-
-    def publish(subject, action, message, options={})
+    def publish(subject, action, message, options = {})
       adapter_class.publish(subject, action, message, options)
     end
 
@@ -37,15 +36,12 @@ module Announce
     def adapter_class
       announce_adapter = Announce.options[:adapter]
       require "announce/adapters/#{announce_adapter.to_s.downcase}_adapter"
-      "::Announce::Adapters::#{announce_adapter.to_s.camelize}Adapter".constantize
+      "::Announce::Adapters::#{announce_adapter.to_s.camelize}Adapter"
+        .constantize
     end
 
     def logger
-      @logger ||= if defined?(Rails)
-        Rails.logger
-      else
-        Logger.new(STDOUT)
-      end
+      @logger ||= defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
     end
 
     def logger=(l)

--- a/lib/announce/adapters/base_adapter.rb
+++ b/lib/announce/adapters/base_adapter.rb
@@ -1,33 +1,37 @@
-require 'announce'
-require 'announce/message'
+require "announce"
+require "announce/message"
 
-# publish, subscribe, and configure_broker are the 3 required methods for an adapter
-# this base adapter also has some helpful base classes, but they are not necessary
-# you could write an adapter from scratch so long as the class has these 3 class methods.
+# publish, subscribe, & configure_broker are the 3 required methods for adapters
+# the base adapter also has helpful base classes, but they are not necessary
+# you can write an adapter from scratch, but these 3 class methods are required.
 module Announce
   module Adapters
     class BaseAdapter
-
       class << self
-
+        # required
         def publish(subject, action, body, options = {})
           topic = adapter_constantize(:topic).new(subject, action, options)
-          msg = Announce::Message.new(subject: subject, action: action, body: body)
+          msg =
+            Announce::Message.new(subject: subject, action: action, body: body)
           topic.publish(msg.to_message, options)
         end
 
+        # required
         def subscribe(worker_class, subject, actions = [], options = {})
           subscriber = adapter_constantize(:subscriber).new
           subscriber.subscribe(worker_class, subject, actions, options)
         end
 
+        # required
         def configure_broker(options)
           broker_manager = adapter_constantize(:broker_manager).new(options)
           broker_manager.configure
         end
 
         def adapter_constantize(name)
-          "::Announce::Adapters::#{Announce.options[:adapter].to_s.camelize}Adapter::#{name.to_s.camelize}".constantize
+          a_klass = Announce.options[:adapter].to_s.camelize
+          klass = name.to_s.camelize
+          "::Announce::Adapters::#{a_klass}Adapter::#{klass}".constantize
         end
       end
 
@@ -97,8 +101,7 @@ module Announce
         end
       end
 
-      class Topic < Destination
-      end
+      class Topic < Destination; end
 
       class Queue < Destination
         def self.name_for(subject, action)

--- a/lib/announce/adapters/base_adapter.rb
+++ b/lib/announce/adapters/base_adapter.rb
@@ -41,8 +41,8 @@ module Announce
         attr_accessor :options
 
         # uses the configuration
-        def initialize(options = Announce.options)
-          @options = options
+        def initialize(options = {})
+          @options = Announce.options.merge(options)
         end
 
         # actually configure the broker queues, topics, and subscriptions
@@ -60,6 +60,10 @@ module Announce
 
         def create
           raise NotImplementedError.new("You must implement create.")
+        end
+
+        def verify
+          raise NotImplementedError.new("You must implement verify.")
         end
 
         def self.name_for(subject, action)

--- a/lib/announce/adapters/inline_adapter.rb
+++ b/lib/announce/adapters/inline_adapter.rb
@@ -1,9 +1,8 @@
-require 'announce/adapters/base_adapter'
+require "announce/adapters/base_adapter"
 
 module Announce
   module Adapters
     class InlineAdapter < BaseAdapter
-
       def self.subscriptions
         @@subscriptions ||= {}
       end
@@ -34,8 +33,7 @@ module Announce
         end
       end
 
-      class Queue < BaseAdapter::Queue
-      end
+      class Queue < BaseAdapter::Queue; end
     end
   end
 end

--- a/lib/announce/adapters/shoryuken_adapter.rb
+++ b/lib/announce/adapters/shoryuken_adapter.rb
@@ -104,8 +104,9 @@ module Announce
 
         def verify_subscription(queue)
           Announce.logger.warn(
-            "Verify Subscription:\n" + "\tfrom SNS Topic: #{arn}\n" +
-              "\tto SQS Queue: #{queue.arn}"
+            "Verify Subscription:\n"\
+            "  from SNS Topic: #{arn}\n"\
+            "  to SQS Queue: #{queue.arn}"
           )
         end
 
@@ -143,9 +144,7 @@ module Announce
           create_attributes =
             default_options.merge((options[:queues] || {}).stringify_keys)
           create_attributes["RedrivePolicy"] =
-            "{\"maxReceiveCount\":\"10\", \"deadLetterTargetArn\":\"#{
-              dlq_arn
-            }\"}\""
+            '{"maxReceiveCount":"10", "deadLetterTargetArn":"' + dlq_arn + '"}'
 
           sqs.create_queue(queue_name: name, attributes: create_attributes)[
             :queue_url
@@ -166,8 +165,8 @@ module Announce
 
         def create_dlq
           dlq_options = {
-            "MaximumMessageSize" => "#{(256 * 1024)}",
-            "MessageRetentionPeriod" => "#{2 * 7 * 24 * 60 * 60}"
+            "MaximumMessageSize" => (256 * 1024).to_s,
+            "MessageRetentionPeriod" => (2 * 7 * 24 * 60 * 60).to_s
             # 2 weeks in seconds
           }
 
@@ -192,11 +191,11 @@ module Announce
         def default_options
           {
             "DelaySeconds" => "0",
-            "MaximumMessageSize" => "#{256 * 1024}",
-            "VisibilityTimeout" => "#{60 * 60}",
+            "MaximumMessageSize" => (256 * 1024).to_s,
+            "VisibilityTimeout" => (60 * 60).to_s,
             # 1 hour in seconds
             "ReceiveMessageWaitTimeSeconds" => "0",
-            "MessageRetentionPeriod" => "#{7 * 24 * 60 * 60}",
+            "MessageRetentionPeriod" => (7 * 24 * 60 * 60).to_s,
             # 1 week in seconds
             "Policy" => policy
           }

--- a/lib/announce/adapters/shoryuken_adapter.rb
+++ b/lib/announce/adapters/shoryuken_adapter.rb
@@ -1,18 +1,16 @@
-require 'shoryuken'
-require 'announce/adapters/base_adapter'
+require "shoryuken"
+require "announce/adapters/base_adapter"
 
 module Announce
   module Adapters
     class ShoryukenAdapter < BaseAdapter
-
       class AnnounceWorker #:nodoc:
         include Shoryuken::Worker
 
         shoryuken_options body_parser: :json, auto_delete: true
 
         # overriden in register_class
-        def job_class
-        end
+        def job_class; end
 
         def perform(sqs_msg, hash)
           job = job_class.new(hash)
@@ -21,7 +19,6 @@ module Announce
       end
 
       class Subscriber < BaseAdapter::Subscriber
-
         def subscribe(worker_class, subject, actions, options)
           Array(actions).each do |action|
             queue_name = Queue.name_for(subject, action)
@@ -42,18 +39,22 @@ module Announce
 
         def active_job?
           defined?(::ActiveJob) &&
-          defined?(ActiveJob::QueueAdapters::ShoryukenAdapter) &&
-          ActiveJob::Base.queue_adapter == ActiveJob::QueueAdapters::ShoryukenAdapter
+            defined?(ActiveJob::QueueAdapters::ShoryukenAdapter) &&
+            ActiveJob::Base.queue_adapter ==
+              ActiveJob::QueueAdapters::ShoryukenAdapter
         end
       end
 
       class BrokerManager < BaseAdapter::BrokerManager
-
         # actually configure the broker queues, topics, and subscriptions
         def configure
           if options[:verify_only]
-            Announce.logger.warn("Running Announce BrokerManager configure in verify_only mode.")
-            Announce.logger.warn("No topics, queues, or subscriptions will be created, please verify the logged resources exist.")
+            Announce.logger.warn(
+              "Running Announce BrokerManager configure in verify_only mode."
+            )
+            Announce.logger.warn(
+              "Resources will be logged, not created; please verify they exist."
+            )
           end
           configure_publishing && configure_subscribing
         end
@@ -62,11 +63,7 @@ module Announce
           (options[:publish] || {}).each do |subject, actions|
             Array(actions).each do |action|
               topic = ShoryukenAdapter::Topic.new(subject, action, options)
-              if options[:verify_only]
-                topic.verify
-              else
-                topic.create
-              end
+              options[:verify_only] ? topic.verify : topic.create
             end
           end
           true
@@ -93,7 +90,6 @@ module Announce
       end
 
       class Topic < BaseAdapter::Topic
-
         def publish(message, options = {})
           Shoryuken::Client.topics(name).send_message(message, options)
         end
@@ -107,20 +103,22 @@ module Announce
         end
 
         def verify_subscription(queue)
-          Announce.logger.warn("Verify Subscription:\n\tfrom SNS Topic: #{arn}\n\tto SQS Queue: #{queue.arn}")
+          Announce.logger.warn(
+            "Verify Subscription:\n" + "\tfrom SNS Topic: #{arn}\n" +
+              "\tto SQS Queue: #{queue.arn}"
+          )
         end
 
         def subscribe(queue)
-          subscription_arn = sns.subscribe(
-            topic_arn: arn,
-            protocol: 'sqs',
-            endpoint: queue.arn
-          )[:subscription_arn]
+          subscription_arn =
+            sns.subscribe(topic_arn: arn, protocol: "sqs", endpoint: queue.arn)[
+              :subscription_arn
+            ]
 
           sns.set_subscription_attributes(
             subscription_arn: subscription_arn,
-            attribute_name: 'RawMessageDelivery',
-            attribute_value: 'true'
+            attribute_name: "RawMessageDelivery",
+            attribute_value: "true"
           )
           subscription_arn
         end
@@ -137,20 +135,27 @@ module Announce
       end
 
       class Queue < BaseAdapter::Queue
-
-        DLQ_SUFFIX = "failures"
+        DLQ_SUFFIX = "failures".freeze
 
         def create
           dlq_arn = create_dlq
 
-          create_attributes = default_options.merge((options[:queues] || {}).stringify_keys)
-          create_attributes['RedrivePolicy'] = %Q{{"maxReceiveCount":"10", "deadLetterTargetArn":"#{dlq_arn}"}"}
+          create_attributes =
+            default_options.merge((options[:queues] || {}).stringify_keys)
+          create_attributes["RedrivePolicy"] =
+            "{\"maxReceiveCount\":\"10\", \"deadLetterTargetArn\":\"#{
+              dlq_arn
+            }\"}\""
 
-          sqs.create_queue(queue_name: name, attributes: create_attributes)[:queue_url]
+          sqs.create_queue(queue_name: name, attributes: create_attributes)[
+            :queue_url
+          ]
         end
 
         def verify
-          Announce.logger.warn("Verify SQS Queue: #{arn}\n\t with DLQ: #{dlq_arn}")
+          Announce.logger.warn(
+            "Verify SQS Queue: #{arn}\n\t with DLQ: #{dlq_arn}"
+          )
         end
 
         def arn
@@ -161,21 +166,19 @@ module Announce
 
         def create_dlq
           dlq_options = {
-            'MaximumMessageSize' => "#{(256 * 1024)}",
-            'MessageRetentionPeriod' => "#{2 * 7 * 24 * 60 * 60}" # 2 weeks in seconds
+            "MaximumMessageSize" => "#{(256 * 1024)}",
+            "MessageRetentionPeriod" => "#{2 * 7 * 24 * 60 * 60}"
+            # 2 weeks in seconds
           }
 
-          dlq = sqs.create_queue(
-            queue_name: dlq_name,
-            attributes: dlq_options
-          )
+          dlq = sqs.create_queue(queue_name: dlq_name, attributes: dlq_options)
 
-          attrs = sqs.get_queue_attributes(
-            queue_url: dlq[:queue_url],
-            attribute_names: ['QueueArn']
-          )
+          attrs =
+            sqs.get_queue_attributes(
+              queue_url: dlq[:queue_url], attribute_names: %w[QueueArn]
+            )
 
-          attrs.attributes['QueueArn']
+          attrs.attributes["QueueArn"]
         end
 
         def dlq_arn
@@ -188,12 +191,14 @@ module Announce
 
         def default_options
           {
-            'DelaySeconds' => '0',
-            'MaximumMessageSize' => "#{256 * 1024}",
-            'VisibilityTimeout' => "#{60 * 60}", # 1 hour in seconds
-            'ReceiveMessageWaitTimeSeconds' => '0',
-            'MessageRetentionPeriod' => "#{7 * 24 * 60 * 60}", # 1 week in seconds
-            'Policy' => policy
+            "DelaySeconds" => "0",
+            "MaximumMessageSize" => "#{256 * 1024}",
+            "VisibilityTimeout" => "#{60 * 60}",
+            # 1 hour in seconds
+            "ReceiveMessageWaitTimeSeconds" => "0",
+            "MessageRetentionPeriod" => "#{7 * 24 * 60 * 60}",
+            # 1 week in seconds
+            "Policy" => policy
           }
         end
 
@@ -207,9 +212,7 @@ module Announce
               {
                 "Sid" => "1",
                 "Effect" => "Allow",
-                "Principal" => {
-                  "AWS" => "*"
-                },
+                "Principal" => { "AWS" => "*" },
                 "Action" => "sqs:*",
                 "Resource" => arn,
                 "Condition" => {
@@ -230,4 +233,6 @@ module Announce
   end
 end
 
-Shoryuken::Client.account_id = ENV['AWS_ACCOUNT_ID'] unless Shoryuken::Client.account_id
+unless Shoryuken::Client.account_id
+  Shoryuken::Client.account_id = ENV["AWS_ACCOUNT_ID"]
+end

--- a/lib/announce/adapters/test_adapter.rb
+++ b/lib/announce/adapters/test_adapter.rb
@@ -1,11 +1,9 @@
-require 'announce/adapters/base_adapter'
+require "announce/adapters/base_adapter"
 
 module Announce
   module Adapters
     class TestAdapter < BaseAdapter
-
       class Subscriber < BaseAdapter::Subscriber
-
         @@subscriptions = []
 
         def self.subscriptions
@@ -35,7 +33,6 @@ module Announce
       end
 
       class Topic < BaseAdapter::Topic
-
         @@published_messages = []
 
         def self.published_messages

--- a/lib/announce/adapters/test_adapter.rb
+++ b/lib/announce/adapters/test_adapter.rb
@@ -50,10 +50,20 @@ module Announce
         def create
           true
         end
+
+        def verify
+          Announce.logger.debug("#{self.class.name}: verify #{name}")
+          true
+        end
       end
 
       class Queue < BaseAdapter::Queue
         def create
+          true
+        end
+
+        def verify
+          Announce.logger.debug("#{self.class.name}: verify #{name}")
           true
         end
       end

--- a/lib/announce/configuration.rb
+++ b/lib/announce/configuration.rb
@@ -1,5 +1,5 @@
-require 'yaml'
-require 'erb'
+require "yaml"
+require "erb"
 
 module Announce
   class Configuration
@@ -14,16 +14,18 @@ module Announce
       {}.tap do |defaults|
         if defined?(ActiveJob)
           defaults[:queue_name_prefix] = ::ActiveJob::Base.queue_name_prefix
-          defaults[:queue_name_delimiter] = ::ActiveJob::Base.queue_name_delimiter
+          defaults[:queue_name_delimiter] =
+            ::ActiveJob::Base.queue_name_delimiter
           defaults[:adapter] = aj_queue_adapter_name
         else
-          defaults[:queue_name_prefix] = ENV['RAILS_ENV'] || ENV['APP_ENV'] || 'development'
-          defaults[:queue_name_delimiter] = '_'
+          defaults[:queue_name_prefix] =
+            ENV["RAILS_ENV"] || ENV["APP_ENV"] || "development"
+          defaults[:queue_name_delimiter] = "_"
           defaults[:adapter] = :inline
         end
 
-        defaults[:app_name] = 'app'
-        defaults[:namespace] = 'announce'
+        defaults[:app_name] = "app"
+        defaults[:namespace] = "announce"
       end
     end
 
@@ -35,7 +37,7 @@ module Announce
     def initialize(options)
       @options = options
       base = defined?(Rails) ? Rails.root : Dir.pwd
-      options[:config_file] ||= File.join(base, 'config', 'announce.yml')
+      options[:config_file] ||= File.join(base, "config", "announce.yml")
     end
 
     def config_file
@@ -45,7 +47,9 @@ module Announce
     def configure
       defaults = self.class.default_options
       if File.exist?(config_file)
-        defaults.merge(YAML.load(ERB.new(IO.read(config_file)).result).symbolize_keys)
+        defaults.merge(
+          YAML.load(ERB.new(IO.read(config_file)).result).symbolize_keys
+        )
       else
         Announce.logger.warn "PubSub file #{config_file} does not exist"
         defaults

--- a/lib/announce/configuration.rb
+++ b/lib/announce/configuration.rb
@@ -48,7 +48,7 @@ module Announce
       defaults = self.class.default_options
       if File.exist?(config_file)
         defaults.merge(
-          YAML.load(ERB.new(IO.read(config_file)).result).symbolize_keys
+          YAML.safe_load(ERB.new(IO.read(config_file)).result).symbolize_keys
         )
       else
         Announce.logger.warn "PubSub file #{config_file} does not exist"

--- a/lib/announce/core_ext.rb
+++ b/lib/announce/core_ext.rb
@@ -1,7 +1,7 @@
 begin
-  require 'active_support/core_ext/hash/keys'
-  require 'active_support/core_ext/hash/deep_merge'
-  require 'active_support/core_ext/hash/slice'
+  require "active_support/core_ext/hash/keys"
+  require "active_support/core_ext/hash/deep_merge"
+  require "active_support/core_ext/hash/slice"
 rescue LoadError
   class Hash
     def stringify_keys
@@ -36,11 +36,11 @@ rescue LoadError
 end
 
 begin
-  require 'active_support/core_ext/string/inflections'
+  require "active_support/core_ext/string/inflections"
 rescue LoadError
   class String
     def constantize
-      names = self.split('::')
+      names = self.split("::")
       names.shift if names.empty? || names.first.empty?
 
       constant = Object
@@ -54,14 +54,14 @@ rescue LoadError
       string = self
       string = string.sub(/^[a-z\d]*/) { $&.capitalize }
       string.gsub!(/(?:_|(\/))([a-z\d]*)/i) { "#{$1}#{$2.capitalize}" }
-      string.gsub!(/\//, '::')
+      string.gsub!(/\//, "::")
       string
     end
 
     def underscore
       camel_cased_word = self
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
-      word = camel_cased_word.to_s.gsub(/::/, '/')
+      word = camel_cased_word.to_s.gsub(/::/, "/")
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
       word.tr!("-", "_")

--- a/lib/announce/message.rb
+++ b/lib/announce/message.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require 'json'
 
 module Announce
@@ -7,7 +8,7 @@ module Announce
 
     def initialize(options={})
       @options = {
-        'message_id' => SecureRandom.uuid,
+        'message_id' => ::SecureRandom.uuid,
         'app' => app,
         'sent_at' => Time.now.utc
       }.merge(options).stringify_keys

--- a/lib/announce/message.rb
+++ b/lib/announce/message.rb
@@ -1,17 +1,17 @@
-require 'securerandom'
-require 'json'
+require "securerandom"
+require "json"
 
 module Announce
   class Message
-
     attr_accessor :options
 
-    def initialize(options={})
-      @options = {
-        'message_id' => ::SecureRandom.uuid,
-        'app' => app,
-        'sent_at' => Time.now.utc
-      }.merge(options).stringify_keys
+    def initialize(options = {})
+      @options =
+        {
+          "message_id" => ::SecureRandom.uuid,
+          "app" => app,
+          "sent_at" => Time.now.utc
+        }.merge(options).stringify_keys
     end
 
     def app

--- a/lib/announce/publisher.rb
+++ b/lib/announce/publisher.rb
@@ -1,5 +1,4 @@
 require 'shoryuken'
-require 'announce'
 require 'announce/message'
 
 module Announce

--- a/lib/announce/publisher.rb
+++ b/lib/announce/publisher.rb
@@ -1,5 +1,5 @@
-require 'shoryuken'
-require 'announce/message'
+require "shoryuken"
+require "announce/message"
 
 module Announce
   module Publisher

--- a/lib/announce/railtie.rb
+++ b/lib/announce/railtie.rb
@@ -1,8 +1,5 @@
 module Announce
   class Railtie < Rails::Railtie
-
-    rake_tasks do
-      load "tasks/announce.rake"
-    end
+    rake_tasks { load "tasks/announce.rake" }
   end
 end

--- a/lib/announce/subscriber.rb
+++ b/lib/announce/subscriber.rb
@@ -1,16 +1,13 @@
 module Announce
   module Subscriber
-
     def self.included(base)
-      base.class_eval do
-        attr_accessor :subject, :action, :message
-      end
+      base.class_eval { attr_accessor :subject, :action, :message }
 
       base.extend(ClassMethods)
     end
 
     module ClassMethods
-      def subscribe_to(subject, actions=[], options = {})
+      def subscribe_to(subject, actions = [], options = {})
         Announce.subscribe(self, subject, actions, options)
       end
     end
@@ -25,19 +22,20 @@ module Announce
       @subject = message[:subject]
       @action = message[:action]
 
-      if [message, subject, action].any? { |a| a.nil? }
-        raise "Message, subject, and action are not all specified for '#{event.inspect}'"
+      if [message, subject, action].any?(&:nil?)
+        raise "Missing message, subject, or action for '#{event.inspect}'"
       end
 
       if respond_to?(delegate_method)
         public_send(delegate_method, message[:body])
       else
-        raise "`#{self.class.name}` is subscribed, but doesn't implement `#{delegate_method}` for '#{event.inspect}'"
+        raise "`#{self.class.name}` subscribed, but doesn't implement " \
+                "`#{delegate_method}` for '#{event.inspect}'"
       end
     end
 
     def delegate_method(message = @message)
-      ['receive', message[:subject], message[:action]].join('_')
+      ["receive", message[:subject], message[:action]].join("_")
     end
   end
 end

--- a/lib/announce/testing.rb
+++ b/lib/announce/testing.rb
@@ -2,7 +2,6 @@ require 'announce/adapters/test_adapter'
 
 module Announce
   module Testing
-
     def published_messages
       Announce::Adapters::TestAdapter::Topic.published_messages
     end

--- a/lib/announce/testing.rb
+++ b/lib/announce/testing.rb
@@ -1,4 +1,3 @@
-require 'announce'
 require 'announce/adapters/test_adapter'
 
 module Announce

--- a/lib/tasks/announce.rake
+++ b/lib/tasks/announce.rake
@@ -5,4 +5,9 @@ namespace :announce do
     Announce.configure
     Announce.configure_broker
   end
+
+  task :verify_config => [:environment] do |t, args|
+    Announce.configure
+    Announce.configure_broker(verify_only: true)
+  end
 end

--- a/lib/tasks/announce.rake
+++ b/lib/tasks/announce.rake
@@ -1,12 +1,12 @@
 namespace :announce do
 
   desc 'Configure the broker destinations'
-  task :configure_broker => [:environment] do |t, args|
+  task configure_broker: [:environment] do
     Announce.configure
     Announce.configure_broker
   end
 
-  task :verify_config => [:environment] do |t, args|
+  task verify_config: [:environment] do
     Announce.configure
     Announce.configure_broker(verify_only: true)
   end

--- a/test/announce/adapters/test_base_adapter.rb
+++ b/test/announce/adapters/test_base_adapter.rb
@@ -6,32 +6,32 @@ describe Announce::Adapters::BaseAdapter do
   let(:base_adapter_class) { Announce::Adapters::BaseAdapter }
 
   it 'can load an adapter class' do
-    base_adapter_class.adapter_constantize(:topic).must_equal Announce::Adapters::TestAdapter::Topic
+    _(base_adapter_class.adapter_constantize(:topic)).must_equal Announce::Adapters::TestAdapter::Topic
   end
 
   it 'can publish a message' do
     base_adapter_class.publish('subject', 'action', 'body', {})
-    last_message['body'].must_equal 'body'
+    _(last_message['body']).must_equal 'body'
   end
 
   it 'can subscribe' do
     base_adapter_class.subscribe(TestSubscriber, 'subject', 'action', {})
     sub = last_subscription
-    sub[0].must_equal TestSubscriber
+    _(sub[0]).must_equal TestSubscriber
   end
 
   it 'can configure the broker' do
     reset_broker_config
-    broker_configured?.must_equal false
+    _(broker_configured?).must_equal false
     base_adapter_class.configure_broker({})
-    broker_configured?.must_equal true
+    _(broker_configured?).must_equal true
   end
 
   it 'can configure the broker without creating queues or topics' do
     reset_broker_config
-    broker_configured?.must_equal false
+    _(broker_configured?).must_equal false
     base_adapter_class.configure_broker({ verify_only: true })
-    broker_configured?.must_equal true
+    _(broker_configured?).must_equal true
   end
 
   describe 'Subscriber' do
@@ -39,9 +39,9 @@ describe Announce::Adapters::BaseAdapter do
     let(:subscriber) { subscriber_class.new }
 
     it 'does not implement subscribe' do
-      lambda do
+      _(lambda do
         subscriber.subscribe(TestSubscriber, 'subject', [], {})
-      end.must_raise NotImplementedError
+      end).must_raise NotImplementedError
     end
   end
 
@@ -50,19 +50,19 @@ describe Announce::Adapters::BaseAdapter do
     let(:broker_manager) { broker_manager_class.new }
 
     it 'defaults to options from announce' do
-      broker_manager.options.wont_be_nil
-      broker_manager.options[:adapter].must_equal 'test'
+      _(broker_manager.options).wont_be_nil
+      _(broker_manager.options[:adapter]).must_equal 'test'
     end
 
     it 'takes options on initialize' do
       bm = broker_manager_class.new(foo: 'bar')
-      bm.options[:foo].must_equal 'bar'
+      _(bm.options[:foo]).must_equal 'bar'
     end
 
     it 'does not implement configure' do
-      lambda do
+      _(lambda do
         broker_manager.configure
-      end.must_raise NotImplementedError
+      end).must_raise NotImplementedError
     end
   end
 
@@ -71,26 +71,26 @@ describe Announce::Adapters::BaseAdapter do
     let(:destination) { destination_class.new('subject', 'action', { foo: 'bar' } ) }
 
     it 'does not implement publish' do
-      lambda do
+      _(lambda do
         destination.publish('message', {})
-      end.must_raise NotImplementedError
+      end).must_raise NotImplementedError
     end
 
     it 'does not implement create' do
-      lambda do
+      _(lambda do
         destination.create
-      end.must_raise NotImplementedError
+      end).must_raise NotImplementedError
     end
 
     it 'returns name for subject, action' do
-      destination_class.name_for('subject', 'action').must_equal 'test_announce_subject_action'
+      _(destination_class.name_for('subject', 'action')).must_equal 'test_announce_subject_action'
     end
 
     it 'initialize with subject, action, options' do
       d = destination_class.new('subject', 'action', { foo: 'bar' } )
-      d.subject.must_equal 'subject'
-      d.action.must_equal 'action'
-      d.options[:foo].must_equal 'bar'
+      _(d.subject).must_equal 'subject'
+      _(d.action).must_equal 'action'
+      _(d.options[:foo]).must_equal 'bar'
     end
   end
 
@@ -103,7 +103,7 @@ describe Announce::Adapters::BaseAdapter do
     let(:queue) { queue_class.new('subject', 'action', { foo: 'bar' } ) }
 
     it 'returns a queue name for subject, action, and this app' do
-      queue_class.name_for('subject', 'action').must_equal 'test_announce_app_subject_action'
+      _(queue_class.name_for('subject', 'action')).must_equal 'test_announce_app_subject_action'
     end
   end
 end

--- a/test/announce/adapters/test_base_adapter.rb
+++ b/test/announce/adapters/test_base_adapter.rb
@@ -27,6 +27,13 @@ describe Announce::Adapters::BaseAdapter do
     broker_configured?.must_equal true
   end
 
+  it 'can configure the broker without creating queues or topics' do
+    reset_broker_config
+    broker_configured?.must_equal false
+    base_adapter_class.configure_broker({ verify_only: true })
+    broker_configured?.must_equal true
+  end
+
   describe 'Subscriber' do
     let(:subscriber_class) { Announce::Adapters::BaseAdapter::Subscriber }
     let(:subscriber) { subscriber_class.new }
@@ -96,7 +103,7 @@ describe Announce::Adapters::BaseAdapter do
     let(:queue) { queue_class.new('subject', 'action', { foo: 'bar' } ) }
 
     it 'returns a queue name for subject, action, and this app' do
-      q = queue_class.name_for('subject', 'action').must_equal 'test_announce_app_subject_action'
+      queue_class.name_for('subject', 'action').must_equal 'test_announce_app_subject_action'
     end
   end
 end

--- a/test/announce/adapters/test_base_adapter.rb
+++ b/test/announce/adapters/test_base_adapter.rb
@@ -32,7 +32,7 @@ describe Announce::Adapters::BaseAdapter do
   it "can configure the broker without creating queues or topics" do
     reset_broker_config
     _(broker_configured?).must_equal false
-    base_adapter_class.configure_broker({ verify_only: true })
+    base_adapter_class.configure_broker(verify_only: true)
     _(broker_configured?).must_equal true
   end
 
@@ -71,7 +71,7 @@ describe Announce::Adapters::BaseAdapter do
   describe "Destination" do
     let(:destination_class) { Announce::Adapters::BaseAdapter::Destination }
     let(:destination) do
-      destination_class.new("subject", "action", { foo: "bar" })
+      destination_class.new("subject", "action", foo: "bar")
     end
 
     it "does not implement publish" do
@@ -91,7 +91,7 @@ describe Announce::Adapters::BaseAdapter do
     end
 
     it "initialize with subject, action, options" do
-      d = destination_class.new("subject", "action", { foo: "bar" })
+      d = destination_class.new("subject", "action", foo: "bar")
       _(d.subject).must_equal "subject"
       _(d.action).must_equal "action"
       _(d.options[:foo]).must_equal "bar"
@@ -104,7 +104,7 @@ describe Announce::Adapters::BaseAdapter do
 
   describe "Queue" do
     let(:queue_class) { Announce::Adapters::BaseAdapter::Queue }
-    let(:queue) { queue_class.new("subject", "action", { foo: "bar" }) }
+    let(:queue) { queue_class.new("subject", "action", foo: "bar") }
 
     it "returns a queue name for subject, action, and this app" do
       _(

--- a/test/announce/adapters/test_base_adapter.rb
+++ b/test/announce/adapters/test_base_adapter.rb
@@ -1,109 +1,115 @@
-require 'test_helper'
-require 'announce/configuration'
-require 'announce/adapters/base_adapter'
+require "test_helper"
+require "announce/configuration"
+require "announce/adapters/base_adapter"
 
 describe Announce::Adapters::BaseAdapter do
   let(:base_adapter_class) { Announce::Adapters::BaseAdapter }
 
-  it 'can load an adapter class' do
-    _(base_adapter_class.adapter_constantize(:topic)).must_equal Announce::Adapters::TestAdapter::Topic
+  it "can load an adapter class" do
+    _(base_adapter_class.adapter_constantize(:topic)).must_equal(
+      Announce::Adapters::TestAdapter::Topic
+    )
   end
 
-  it 'can publish a message' do
-    base_adapter_class.publish('subject', 'action', 'body', {})
-    _(last_message['body']).must_equal 'body'
+  it "can publish a message" do
+    base_adapter_class.publish("subject", "action", "body", {})
+    _(last_message["body"]).must_equal "body"
   end
 
-  it 'can subscribe' do
-    base_adapter_class.subscribe(TestSubscriber, 'subject', 'action', {})
+  it "can subscribe" do
+    base_adapter_class.subscribe(TestSubscriber, "subject", "action", {})
     sub = last_subscription
     _(sub[0]).must_equal TestSubscriber
   end
 
-  it 'can configure the broker' do
+  it "can configure the broker" do
     reset_broker_config
     _(broker_configured?).must_equal false
     base_adapter_class.configure_broker({})
     _(broker_configured?).must_equal true
   end
 
-  it 'can configure the broker without creating queues or topics' do
+  it "can configure the broker without creating queues or topics" do
     reset_broker_config
     _(broker_configured?).must_equal false
     base_adapter_class.configure_broker({ verify_only: true })
     _(broker_configured?).must_equal true
   end
 
-  describe 'Subscriber' do
+  describe "Subscriber" do
     let(:subscriber_class) { Announce::Adapters::BaseAdapter::Subscriber }
     let(:subscriber) { subscriber_class.new }
 
-    it 'does not implement subscribe' do
-      _(lambda do
-        subscriber.subscribe(TestSubscriber, 'subject', [], {})
-      end).must_raise NotImplementedError
+    it "does not implement subscribe" do
+      _(
+        -> { subscriber.subscribe(TestSubscriber, "subject", [], {}) }
+      ).must_raise NotImplementedError
     end
   end
 
-  describe 'BrokerManager' do
-    let(:broker_manager_class) { Announce::Adapters::BaseAdapter::BrokerManager }
+  describe "BrokerManager" do
+    let(:broker_manager_class) do
+      Announce::Adapters::BaseAdapter::BrokerManager
+    end
     let(:broker_manager) { broker_manager_class.new }
 
-    it 'defaults to options from announce' do
+    it "defaults to options from announce" do
       _(broker_manager.options).wont_be_nil
-      _(broker_manager.options[:adapter]).must_equal 'test'
+      _(broker_manager.options[:adapter]).must_equal "test"
     end
 
-    it 'takes options on initialize' do
-      bm = broker_manager_class.new(foo: 'bar')
-      _(bm.options[:foo]).must_equal 'bar'
+    it "takes options on initialize" do
+      bm = broker_manager_class.new(foo: "bar")
+      _(bm.options[:foo]).must_equal "bar"
     end
 
-    it 'does not implement configure' do
-      _(lambda do
-        broker_manager.configure
-      end).must_raise NotImplementedError
+    it "does not implement configure" do
+      _(-> { broker_manager.configure }).must_raise NotImplementedError
     end
   end
 
-  describe 'Destination' do
+  describe "Destination" do
     let(:destination_class) { Announce::Adapters::BaseAdapter::Destination }
-    let(:destination) { destination_class.new('subject', 'action', { foo: 'bar' } ) }
-
-    it 'does not implement publish' do
-      _(lambda do
-        destination.publish('message', {})
-      end).must_raise NotImplementedError
+    let(:destination) do
+      destination_class.new("subject", "action", { foo: "bar" })
     end
 
-    it 'does not implement create' do
-      _(lambda do
-        destination.create
-      end).must_raise NotImplementedError
+    it "does not implement publish" do
+      _(
+        -> { destination.publish("message", {}) }
+      ).must_raise NotImplementedError
     end
 
-    it 'returns name for subject, action' do
-      _(destination_class.name_for('subject', 'action')).must_equal 'test_announce_subject_action'
+    it "does not implement create" do
+      _(-> { destination.create }).must_raise NotImplementedError
     end
 
-    it 'initialize with subject, action, options' do
-      d = destination_class.new('subject', 'action', { foo: 'bar' } )
-      _(d.subject).must_equal 'subject'
-      _(d.action).must_equal 'action'
-      _(d.options[:foo]).must_equal 'bar'
+    it "returns name for subject, action" do
+      _(
+        destination_class.name_for("subject", "action")
+      ).must_equal "test_announce_subject_action"
+    end
+
+    it "initialize with subject, action, options" do
+      d = destination_class.new("subject", "action", { foo: "bar" })
+      _(d.subject).must_equal "subject"
+      _(d.action).must_equal "action"
+      _(d.options[:foo]).must_equal "bar"
     end
   end
 
-  describe 'Topic' do
+  describe "Topic" do
     # exactly like destination, do nothing here
   end
 
-  describe 'Queue' do
+  describe "Queue" do
     let(:queue_class) { Announce::Adapters::BaseAdapter::Queue }
-    let(:queue) { queue_class.new('subject', 'action', { foo: 'bar' } ) }
+    let(:queue) { queue_class.new("subject", "action", { foo: "bar" }) }
 
-    it 'returns a queue name for subject, action, and this app' do
-      _(queue_class.name_for('subject', 'action')).must_equal 'test_announce_app_subject_action'
+    it "returns a queue name for subject, action, and this app" do
+      _(
+        queue_class.name_for("subject", "action")
+      ).must_equal "test_announce_app_subject_action"
     end
   end
 end

--- a/test/announce/adapters/test_inline_adapter.rb
+++ b/test/announce/adapters/test_inline_adapter.rb
@@ -1,7 +1,7 @@
-require 'test_helper'
-require 'announce/configuration'
-require 'announce/adapters/base_adapter'
-require 'announce/adapters/inline_adapter'
+require "test_helper"
+require "announce/configuration"
+require "announce/adapters/base_adapter"
+require "announce/adapters/inline_adapter"
 
 describe Announce::Adapters::InlineAdapter do
   before { Announce.options[:adapter] = :inline }
@@ -9,39 +9,39 @@ describe Announce::Adapters::InlineAdapter do
 
   let(:inline_adapter_class) { Announce::Adapters::InlineAdapter }
 
-  it 'can load an adapter class' do
+  it "can load an adapter class" do
     _(
       inline_adapter_class.adapter_constantize(:topic)
     ).must_equal Announce::Adapters::InlineAdapter::Topic
   end
 
-  describe 'Subscriber' do
+  describe "Subscriber" do
     before { Announce::Adapters::InlineAdapter.subscriptions.clear }
 
     let(:subscriber_class) { Announce::Adapters::InlineAdapter::Subscriber }
     let(:subscriber) { subscriber_class.new }
 
-    it 'implements subscribe' do
-      subscriber.subscribe(TestSubscriber, 'subject', %w[create delete], {})
+    it "implements subscribe" do
+      subscriber.subscribe(TestSubscriber, "subject", %w[create delete], {})
       subs = Announce::Adapters::InlineAdapter.subscriptions
-      _(subs['test_announce_app_subject_create']).must_equal TestSubscriber
-      _(subs['test_announce_app_subject_delete']).must_equal TestSubscriber
+      _(subs["test_announce_app_subject_create"]).must_equal TestSubscriber
+      _(subs["test_announce_app_subject_delete"]).must_equal TestSubscriber
     end
   end
 
-  describe 'Topic' do
+  describe "Topic" do
     let(:subscriber_class) { Announce::Adapters::InlineAdapter::Subscriber }
     let(:subscriber) { subscriber_class.new }
 
     let(:topic_class) { Announce::Adapters::InlineAdapter::Topic }
-    let(:topic) { topic_class.new('subject', 'action') }
+    let(:topic) { topic_class.new("subject", "action") }
 
     before do
       Announce::Adapters::InlineAdapter.subscriptions.clear
-      subscriber.subscribe(TestSubscriber, 'subject', %w[action], {})
+      subscriber.subscribe(TestSubscriber, "subject", %w[action], {})
     end
 
-    it 'implements publish' do
+    it "implements publish" do
       msg =
         Announce::Message.new(
           subject: topic.subject, action: topic.action, body: { subject_id: 1 }

--- a/test/announce/adapters/test_inline_adapter.rb
+++ b/test/announce/adapters/test_inline_adapter.rb
@@ -11,7 +11,7 @@ describe Announce::Adapters::InlineAdapter do
   let(:inline_adapter_class) { Announce::Adapters::InlineAdapter }
 
   it 'can load an adapter class' do
-    inline_adapter_class.adapter_constantize(:topic).must_equal Announce::Adapters::InlineAdapter::Topic
+    _(inline_adapter_class.adapter_constantize(:topic)).must_equal Announce::Adapters::InlineAdapter::Topic
   end
 
   describe 'Subscriber' do
@@ -23,8 +23,8 @@ describe Announce::Adapters::InlineAdapter do
     it 'implements subscribe' do
       subscriber.subscribe(TestSubscriber, 'subject', ['create', 'delete'], {})
       subs = Announce::Adapters::InlineAdapter.subscriptions
-      subs['test_announce_app_subject_create'].must_equal TestSubscriber
-      subs['test_announce_app_subject_delete'].must_equal TestSubscriber
+      _(subs['test_announce_app_subject_create']).must_equal TestSubscriber
+      _(subs['test_announce_app_subject_delete']).must_equal TestSubscriber
     end
   end
 
@@ -44,7 +44,7 @@ describe Announce::Adapters::InlineAdapter do
       msg = Announce::Message.new(subject: topic.subject, action: topic.action, body: { subject_id: 1 } )
       topic.publish(msg.to_message)
       received = TestSubscriber.received.pop
-      received[:subject_id].must_equal 1
+      _(received[:subject_id]).must_equal 1
     end
   end
 end

--- a/test/announce/adapters/test_inline_adapter.rb
+++ b/test/announce/adapters/test_inline_adapter.rb
@@ -4,14 +4,15 @@ require 'announce/adapters/base_adapter'
 require 'announce/adapters/inline_adapter'
 
 describe Announce::Adapters::InlineAdapter do
-
   before { Announce.options[:adapter] = :inline }
   after { reset_announce }
 
   let(:inline_adapter_class) { Announce::Adapters::InlineAdapter }
 
   it 'can load an adapter class' do
-    _(inline_adapter_class.adapter_constantize(:topic)).must_equal Announce::Adapters::InlineAdapter::Topic
+    _(
+      inline_adapter_class.adapter_constantize(:topic)
+    ).must_equal Announce::Adapters::InlineAdapter::Topic
   end
 
   describe 'Subscriber' do
@@ -21,7 +22,7 @@ describe Announce::Adapters::InlineAdapter do
     let(:subscriber) { subscriber_class.new }
 
     it 'implements subscribe' do
-      subscriber.subscribe(TestSubscriber, 'subject', ['create', 'delete'], {})
+      subscriber.subscribe(TestSubscriber, 'subject', %w[create delete], {})
       subs = Announce::Adapters::InlineAdapter.subscriptions
       _(subs['test_announce_app_subject_create']).must_equal TestSubscriber
       _(subs['test_announce_app_subject_delete']).must_equal TestSubscriber
@@ -35,13 +36,16 @@ describe Announce::Adapters::InlineAdapter do
     let(:topic_class) { Announce::Adapters::InlineAdapter::Topic }
     let(:topic) { topic_class.new('subject', 'action') }
 
-    before {
+    before do
       Announce::Adapters::InlineAdapter.subscriptions.clear
-      subscriber.subscribe(TestSubscriber, 'subject', ['action'], {})
-    }
+      subscriber.subscribe(TestSubscriber, 'subject', %w[action], {})
+    end
 
     it 'implements publish' do
-      msg = Announce::Message.new(subject: topic.subject, action: topic.action, body: { subject_id: 1 } )
+      msg =
+        Announce::Message.new(
+          subject: topic.subject, action: topic.action, body: { subject_id: 1 }
+        )
       topic.publish(msg.to_message)
       received = TestSubscriber.received.pop
       _(received[:subject_id]).must_equal 1

--- a/test/announce/adapters/test_shoryuken_adapter.rb
+++ b/test/announce/adapters/test_shoryuken_adapter.rb
@@ -1,38 +1,36 @@
-require 'test_helper'
-require 'announce/configuration'
-require 'announce/adapters/base_adapter'
-require 'announce/adapters/shoryuken_adapter'
-require 'ostruct'
+require "test_helper"
+require "announce/configuration"
+require "announce/adapters/base_adapter"
+require "announce/adapters/shoryuken_adapter"
+require "ostruct"
 
 describe Announce::Adapters::ShoryukenAdapter do
-
-  before {
+  before do
     Announce.options[:adapter] = :shoryuken
     Shoryuken.logger.level = Logger::ERROR
     Shoryuken.queues.clear
-    config_file = File.join(File.dirname(__FILE__), 'shoryuken.yml')
+    config_file = File.join(File.dirname(__FILE__), "shoryuken.yml")
     Shoryuken::EnvironmentLoader.load(config_file: config_file)
-  }
+  end
 
   after { reset_announce }
 
   let(:shoryuken_adapter_class) { Announce::Adapters::ShoryukenAdapter }
 
-  it 'can load an adapter class' do
-    _(shoryuken_adapter_class.adapter_constantize(:topic)).must_equal Announce::Adapters::ShoryukenAdapter::Topic
+  it "can load an adapter class" do
+    _(
+      shoryuken_adapter_class.adapter_constantize(:topic)
+    ).must_equal Announce::Adapters::ShoryukenAdapter::Topic
   end
 
-  describe 'BrokerManager' do
+  describe "BrokerManager" do
     let(:broker_options) do
-      {
-        publish: { subject: ['action'] },
-        subscribe: { subject: ['action'] }
-      }
+      { publish: { subject: %w[action] }, subscribe: { subject: %w[action] } }
     end
     let(:manager_class) { Announce::Adapters::ShoryukenAdapter::BrokerManager }
     let(:manager) { manager_class.new(broker_options) }
 
-    it 'configures for publish and subscribe' do
+    it "configures for publish and subscribe" do
       manager.stub(:configure_publishing, true) do
         manager.stub(:configure_subscribing, true) do
           _(manager.configure).must_equal true
@@ -40,100 +38,114 @@ describe Announce::Adapters::ShoryukenAdapter do
       end
     end
 
-    it 'can configure topics for publishing' do
-      Shoryuken::Client.sns.stub(:create_topic, { topic_arn: 'arn' } ) do
+    it "can configure topics for publishing" do
+      Shoryuken::Client.sns.stub(:create_topic, { topic_arn: "arn" }) do
         _(manager.configure_publishing).must_equal true
       end
     end
 
-    it 'can configure queues, topics, and subscriptions for receiving' do
+    it "can configure queues, topics, and subscriptions for receiving" do
       sns = Minitest::Mock.new
-      sns.expect(:config, {region: 'us-east-1'})
-      sns.expect(:create_topic, { topic_arn: 'arn' }, [Hash])
-      sns.expect(:subscribe, { subscription_arn: 'arn' }, [Hash])
+      sns.expect(:config, { region: "us-east-1" })
+      sns.expect(:create_topic, { topic_arn: "arn" }, [Hash])
+      sns.expect(:subscribe, { subscription_arn: "arn" }, [Hash])
       sns.expect(:set_subscription_attributes, true, [Hash])
 
       sqs = Minitest::Mock.new
-      sqs.expect(:config, {region: 'us-east-1'})
-      sqs.expect(:config, {region: 'us-east-1'})
-      sqs.expect(:config, {region: 'us-east-1'})
-      sqs.expect(:create_queue, { queue_url: 'url' }, [Hash])
-      sqs.expect(:create_queue, { queue_url: 'url' }, [Hash])
+      sqs.expect(:config, { region: "us-east-1" })
+      sqs.expect(:config, { region: "us-east-1" })
+      sqs.expect(:config, { region: "us-east-1" })
+      sqs.expect(:create_queue, { queue_url: "url" }, [Hash])
+      sqs.expect(:create_queue, { queue_url: "url" }, [Hash])
 
-      qua = OpenStruct.new(attributes: { 'QueueArn' => 'arn' })
+      qua = OpenStruct.new(attributes: { "QueueArn" => "arn" })
       sqs.expect(:get_queue_attributes, qua, [Hash])
 
       Shoryuken::Client.stub(:sns, sns) do
-        Shoryuken::Client.stub(:sqs, sqs) do
-          manager.configure_subscribing
-        end
+        Shoryuken::Client.stub(:sqs, sqs) { manager.configure_subscribing }
       end
     end
 
-    it 'verifies configuration' do
+    it "verifies configuration" do
       logging_io = StringIO.new
       Announce.logger = Logger.new(logging_io)
-      verify_manager = manager_class.new(broker_options.merge({verify_only: true}))
-      verify_manager.configure()
-      Announce.logger = Logger.new('/dev/null')
+      verify_manager =
+        manager_class.new(broker_options.merge({ verify_only: true }))
+      verify_manager.configure
+      Announce.logger = Logger.new("/dev/null")
       logging = logging_io.string
-      _(logging).must_match(/Verify SQS Queue: arn:aws:sqs:.*:test_announce_app_subject_action/)
-      _(logging).must_match(/Verify SNS Topic: arn:aws:sns:.*:test_announce_subject_action/)
+      _(logging).must_match(
+        /Verify SQS Queue: arn:aws:sqs:.*:test_announce_app_subject_action/
+      )
+      _(logging).must_match(
+        /Verify SNS Topic: arn:aws:sns:.*:test_announce_subject_action/
+      )
       _(logging).must_match(/Verify Subscription/)
-      _(logging).must_match(/from SNS Topic: arn:aws:sns:.*:test_announce_subject_action/)
-      _(logging).must_match(/to SQS Queue: arn:aws:sqs:.*:test_announce_app_subject_action/)
+      _(logging).must_match(
+        /from SNS Topic: arn:aws:sns:.*:test_announce_subject_action/
+      )
+      _(logging).must_match(
+        /to SQS Queue: arn:aws:sqs:.*:test_announce_app_subject_action/
+      )
     end
   end
 
-  describe 'Subscriber' do
-    before {
+  describe "Subscriber" do
+    before do
       Shoryuken.queues.clear
       Shoryuken.worker_registry.clear
-    }
+    end
 
     let(:subscriber_class) { Announce::Adapters::ShoryukenAdapter::Subscriber }
     let(:subscriber) { subscriber_class.new }
 
-    it 'implements subscribe' do
-      subscriber.subscribe(TestSubscriber, 'subject', ['create', 'delete'], {})
-      _(Shoryuken.worker_registry.workers('test_announce_app_subject_create')).must_equal [TestSubscriber]
-      _(Shoryuken.worker_registry.workers('test_announce_app_subject_delete')).must_equal [TestSubscriber]
+    it "implements subscribe" do
+      subscriber.subscribe(TestSubscriber, "subject", %w[create delete], {})
+      _(
+        Shoryuken.worker_registry.workers("test_announce_app_subject_create")
+      ).must_equal [TestSubscriber]
+      _(
+        Shoryuken.worker_registry.workers("test_announce_app_subject_delete")
+      ).must_equal [TestSubscriber]
     end
   end
 
-  describe 'Topic' do
-
-    before {
+  describe "Topic" do
+    before do
       Shoryuken.queues.clear
       Shoryuken.worker_registry.clear
-    }
+    end
 
     let(:subscriber_class) { Announce::Adapters::ShoryukenAdapter::Subscriber }
     let(:subscriber) { subscriber_class.new }
 
     let(:topic_class) { Announce::Adapters::ShoryukenAdapter::Topic }
-    let(:topic) { topic_class.new('subject', 'action') }
+    let(:topic) { topic_class.new("subject", "action") }
 
-    before {
-      subscriber.subscribe(TestSubscriber, 'subject', ['action'], {})
-    }
+    before { subscriber.subscribe(TestSubscriber, "subject", %w[action], {}) }
 
-    it 'implements publish' do
-      msg = Announce::Message.new(subject: topic.subject, action: topic.action, body: { subject_id: 1 } )
-      shoryuken_topic = Shoryuken::Client.topics('test_announce_subject_action')
+    it "implements publish" do
+      msg =
+        Announce::Message.new(
+          subject: topic.subject, action: topic.action, body: { subject_id: 1 }
+        )
+      shoryuken_topic = Shoryuken::Client.topics("test_announce_subject_action")
       shoryuken_topic.stub(:send_message, true) do
         topic.publish(msg.to_message)
       end
     end
 
-    it 'can create the topic in SNS' do
-      topic.sns.stub(:create_topic, {topic_arn: 'arn:aws:sns:us-east-1:account_id:test_announce_app_subject_action'}) do
-        _(topic.create).must_equal 'arn:aws:sns:us-east-1:account_id:test_announce_app_subject_action'
+    it "can create the topic in SNS" do
+      test_arn =
+        "arn:aws:sns:us-east-1:account_id:test_announce_app_subject_action"
+      topic.sns.stub(:create_topic, { topic_arn: test_arn }) do
+        _(topic.create).must_equal test_arn
       end
     end
 
-    it 'returns the ARN' do
-      _(topic.arn).must_equal 'arn:aws:sns:us-east-1:123456789012:test_announce_subject_action'
+    it "returns the ARN" do
+      arn = "arn:aws:sns:us-east-1:123456789012:test_announce_subject_action"
+      _(topic.arn).must_equal arn
     end
   end
 end

--- a/test/announce/adapters/test_shoryuken_adapter.rb
+++ b/test/announce/adapters/test_shoryuken_adapter.rb
@@ -19,7 +19,7 @@ describe Announce::Adapters::ShoryukenAdapter do
   let(:shoryuken_adapter_class) { Announce::Adapters::ShoryukenAdapter }
 
   it 'can load an adapter class' do
-    shoryuken_adapter_class.adapter_constantize(:topic).must_equal Announce::Adapters::ShoryukenAdapter::Topic
+    _(shoryuken_adapter_class.adapter_constantize(:topic)).must_equal Announce::Adapters::ShoryukenAdapter::Topic
   end
 
   describe 'BrokerManager' do
@@ -35,19 +35,18 @@ describe Announce::Adapters::ShoryukenAdapter do
     it 'configures for publish and subscribe' do
       manager.stub(:configure_publishing, true) do
         manager.stub(:configure_subscribing, true) do
-          manager.configure.must_equal true
+          _(manager.configure).must_equal true
         end
       end
     end
 
     it 'can configure topics for publishing' do
       Shoryuken::Client.sns.stub(:create_topic, { topic_arn: 'arn' } ) do
-        manager.configure_publishing.must_equal true
+        _(manager.configure_publishing).must_equal true
       end
     end
 
     it 'can configure queues, topics, and subscriptions for receiving' do
-
       sns = Minitest::Mock.new
       sns.expect(:config, {region: 'us-east-1'})
       sns.expect(:create_topic, { topic_arn: 'arn' }, [Hash])
@@ -70,6 +69,20 @@ describe Announce::Adapters::ShoryukenAdapter do
         end
       end
     end
+
+    it 'verifies configuration' do
+      logging_io = StringIO.new
+      Announce.logger = Logger.new(logging_io)
+      verify_manager = manager_class.new(broker_options.merge({verify_only: true}))
+      verify_manager.configure()
+      Announce.logger = Logger.new('/dev/null')
+      logging = logging_io.string
+      _(logging).must_match(/Verify SQS Queue: arn:aws:sqs:.*:test_announce_app_subject_action/)
+      _(logging).must_match(/Verify SNS Topic: arn:aws:sns:.*:test_announce_subject_action/)
+      _(logging).must_match(/Verify Subscription/)
+      _(logging).must_match(/from SNS Topic: arn:aws:sns:.*:test_announce_subject_action/)
+      _(logging).must_match(/to SQS Queue: arn:aws:sqs:.*:test_announce_app_subject_action/)
+    end
   end
 
   describe 'Subscriber' do
@@ -83,8 +96,8 @@ describe Announce::Adapters::ShoryukenAdapter do
 
     it 'implements subscribe' do
       subscriber.subscribe(TestSubscriber, 'subject', ['create', 'delete'], {})
-      Shoryuken.worker_registry.workers('test_announce_app_subject_create').must_equal [TestSubscriber]
-      Shoryuken.worker_registry.workers('test_announce_app_subject_delete').must_equal [TestSubscriber]
+      _(Shoryuken.worker_registry.workers('test_announce_app_subject_create')).must_equal [TestSubscriber]
+      _(Shoryuken.worker_registry.workers('test_announce_app_subject_delete')).must_equal [TestSubscriber]
     end
   end
 
@@ -115,12 +128,12 @@ describe Announce::Adapters::ShoryukenAdapter do
 
     it 'can create the topic in SNS' do
       topic.sns.stub(:create_topic, {topic_arn: 'arn:aws:sns:us-east-1:account_id:test_announce_app_subject_action'}) do
-        sub = topic.create.must_equal 'arn:aws:sns:us-east-1:account_id:test_announce_app_subject_action'
+        _(topic.create).must_equal 'arn:aws:sns:us-east-1:account_id:test_announce_app_subject_action'
       end
     end
 
     it 'returns the ARN' do
-      topic.arn.must_equal 'arn:aws:sns:us-east-1:123456789012:test_announce_subject_action'
+      _(topic.arn).must_equal 'arn:aws:sns:us-east-1:123456789012:test_announce_subject_action'
     end
   end
 end

--- a/test/announce/adapters/test_shoryuken_adapter.rb
+++ b/test/announce/adapters/test_shoryuken_adapter.rb
@@ -69,8 +69,8 @@ describe Announce::Adapters::ShoryukenAdapter do
     it "verifies configuration" do
       logging_io = StringIO.new
       Announce.logger = Logger.new(logging_io)
-      verify_manager =
-        manager_class.new(broker_options.merge({ verify_only: true }))
+      opts = broker_options.merge(verify_only: true)
+      verify_manager = manager_class.new(opts)
       verify_manager.configure
       Announce.logger = Logger.new("/dev/null")
       logging = logging_io.string

--- a/test/announce/test_configuration.rb
+++ b/test/announce/test_configuration.rb
@@ -35,9 +35,11 @@ describe Announce::Configuration do
             def queue_name_prefix
               "activejob"
             end
+
             def queue_name_delimiter
               "-"
             end
+
             def queue_adapter
               ActiveJob::QueueAdapters::FakeAdapter
             end

--- a/test/announce/test_configuration.rb
+++ b/test/announce/test_configuration.rb
@@ -1,55 +1,57 @@
-require 'test_helper'
-require 'announce/configuration'
+require "test_helper"
+require "announce/configuration"
 
 describe Announce::Configuration do
-
   before(:each) { reset_announce }
   after(:each) { reset_announce }
 
-  it 'has default options' do
+  it "has default options" do
     defaults = Announce::Configuration.default_options
-    _(defaults[:queue_name_prefix]).must_equal 'test'
+    _(defaults[:queue_name_prefix]).must_equal "test"
     _(defaults[:adapter]).must_equal :inline
   end
 
-  it 'will return empty hash without a config file' do
-    Announce::Configuration.configure(config_file: 'doesntexist.yml')
+  it "will return empty hash without a config file" do
+    Announce::Configuration.configure(config_file: "doesntexist.yml")
     _(Announce.options).wont_be_nil
   end
 
-  it 'will return config from a file' do
-    file = File.join(File.dirname(__FILE__), 'announce.yml')
+  it "will return config from a file" do
+    file = File.join(File.dirname(__FILE__), "announce.yml")
     Announce::Configuration.configure(config_file: file)
     _(Announce.options).wont_be_nil
     _(Announce.options[:subscribe]).wont_be_nil
     _(Announce.options[:publish]).wont_be_nil
   end
 
-  describe 'ActiveJob' do
-    before {
+  describe "ActiveJob" do
+    before do
       module ::ActiveJob
         module QueueAdapters
-          class FakeAdapter
-          end
+          class FakeAdapter; end
         end
         class Base
           class << self
-            def queue_name_prefix; 'activejob'; end
-            def queue_name_delimiter; '-'; end
-            def queue_adapter; ActiveJob::QueueAdapters::FakeAdapter; end
+            def queue_name_prefix
+              "activejob"
+            end
+            def queue_name_delimiter
+              "-"
+            end
+            def queue_adapter
+              ActiveJob::QueueAdapters::FakeAdapter
+            end
           end
         end
       end
-    }
+    end
 
-    after {
-      Object.send(:remove_const, 'ActiveJob')
-    }
+    after { Object.send(:remove_const, "ActiveJob") }
 
-    it 'loads config using ActiveJob defaults' do
+    it "loads config using ActiveJob defaults" do
       defaults = Announce::Configuration.default_options
-      _(defaults[:queue_name_prefix]).must_equal 'activejob'
-      _(defaults[:adapter]).must_equal 'fake'
+      _(defaults[:queue_name_prefix]).must_equal "activejob"
+      _(defaults[:adapter]).must_equal "fake"
     end
   end
 end

--- a/test/announce/test_configuration.rb
+++ b/test/announce/test_configuration.rb
@@ -8,21 +8,21 @@ describe Announce::Configuration do
 
   it 'has default options' do
     defaults = Announce::Configuration.default_options
-    defaults[:queue_name_prefix].must_equal 'test'
-    defaults[:adapter].must_equal :inline
+    _(defaults[:queue_name_prefix]).must_equal 'test'
+    _(defaults[:adapter]).must_equal :inline
   end
 
   it 'will return empty hash without a config file' do
     Announce::Configuration.configure(config_file: 'doesntexist.yml')
-    Announce.options.wont_be_nil
+    _(Announce.options).wont_be_nil
   end
 
   it 'will return config from a file' do
     file = File.join(File.dirname(__FILE__), 'announce.yml')
     Announce::Configuration.configure(config_file: file)
-    Announce.options.wont_be_nil
-    Announce.options[:subscribe].wont_be_nil
-    Announce.options[:publish].wont_be_nil
+    _(Announce.options).wont_be_nil
+    _(Announce.options[:subscribe]).wont_be_nil
+    _(Announce.options[:publish]).wont_be_nil
   end
 
   describe 'ActiveJob' do
@@ -48,8 +48,8 @@ describe Announce::Configuration do
 
     it 'loads config using ActiveJob defaults' do
       defaults = Announce::Configuration.default_options
-      defaults[:queue_name_prefix].must_equal 'activejob'
-      defaults[:adapter].must_equal 'fake'
+      _(defaults[:queue_name_prefix]).must_equal 'activejob'
+      _(defaults[:adapter]).must_equal 'fake'
     end
   end
 end

--- a/test/announce/test_core_ext.rb
+++ b/test/announce/test_core_ext.rb
@@ -1,40 +1,41 @@
-require 'test_helper'
-require 'announce/core_ext'
+require "test_helper"
+require "announce/core_ext"
 
-describe 'Announce core extensions' do
-
-  describe 'Hash' do
-    it 'will stringify keys' do
-      _({:key => 'val'}.stringify_keys.keys.first).must_equal 'key'
+describe "Announce core extensions" do
+  describe "Hash" do
+    it "will stringify keys" do
+      _({ key: "val" }.stringify_keys.keys.first).must_equal "key"
     end
 
-    it 'will symbolize keys' do
-      _({'key' => 'val'}.symbolize_keys.keys.first).must_equal :key
+    it "will symbolize keys" do
+      _({ "key" => "val" }.symbolize_keys.keys.first).must_equal :key
     end
 
-    it 'will deep symbolize keys' do
-      _({'key1' => { 'key2' => 'val' } }.deep_symbolize_keys[:key1].keys.first).must_equal :key2
+    it "will deep symbolize keys" do
+      _(
+        { "key1" => { "key2" => "val" } }.deep_symbolize_keys[:key1].keys.first
+      ).must_equal :key2
     end
 
-    it 'will slice key value pairs from a Hash' do
-      _({a: 1, b: 2, c: 3}.slice(:a, :c).keys.sort).must_equal [:a, :c]
+    it "will slice key value pairs from a Hash" do
+      _({ a: 1, b: 2, c: 3 }.slice(:a, :c).keys.sort).must_equal %i[a c]
     end
   end
 
-  describe 'String' do
-    it 'returns a class from a string' do
+  describe "String" do
+    it "returns a class from a string" do
       class HelloWorld; end
-      _('HelloWorld'.constantize).must_equal HelloWorld
+      _("HelloWorld".constantize).must_equal HelloWorld
     end
 
-    it 'changes string to camel case' do
-      _('this_is_sweet'.camelize).must_equal 'ThisIsSweet'
-      _('yeah/this_is_sweet'.camelize).must_equal 'Yeah::ThisIsSweet'
+    it "changes string to camel case" do
+      _("this_is_sweet".camelize).must_equal "ThisIsSweet"
+      _("yeah/this_is_sweet".camelize).must_equal "Yeah::ThisIsSweet"
     end
 
-    it 'changes CamelCase to under_score' do
-      _('ThisIsSweet'.underscore).must_equal 'this_is_sweet'
-      _('Yeah::ThisIsSweet'.underscore).must_equal 'yeah/this_is_sweet'
+    it "changes CamelCase to under_score" do
+      _("ThisIsSweet".underscore).must_equal "this_is_sweet"
+      _("Yeah::ThisIsSweet".underscore).must_equal "yeah/this_is_sweet"
     end
   end
 end

--- a/test/announce/test_core_ext.rb
+++ b/test/announce/test_core_ext.rb
@@ -5,36 +5,36 @@ describe 'Announce core extensions' do
 
   describe 'Hash' do
     it 'will stringify keys' do
-      {:key => 'val'}.stringify_keys.keys.first.must_equal 'key'
+      _({:key => 'val'}.stringify_keys.keys.first).must_equal 'key'
     end
 
     it 'will symbolize keys' do
-      {'key' => 'val'}.symbolize_keys.keys.first.must_equal :key
+      _({'key' => 'val'}.symbolize_keys.keys.first).must_equal :key
     end
 
     it 'will deep symbolize keys' do
-      {'key1' => { 'key2' => 'val' } }.deep_symbolize_keys[:key1].keys.first.must_equal :key2
+      _({'key1' => { 'key2' => 'val' } }.deep_symbolize_keys[:key1].keys.first).must_equal :key2
     end
 
     it 'will slice key value pairs from a Hash' do
-      {a: 1, b: 2, c: 3}.slice(:a, :c).keys.sort.must_equal [:a, :c]
+      _({a: 1, b: 2, c: 3}.slice(:a, :c).keys.sort).must_equal [:a, :c]
     end
   end
 
   describe 'String' do
     it 'returns a class from a string' do
       class HelloWorld; end
-      'HelloWorld'.constantize.must_equal HelloWorld
+      _('HelloWorld'.constantize).must_equal HelloWorld
     end
 
     it 'changes string to camel case' do
-      'this_is_sweet'.camelize.must_equal 'ThisIsSweet'
-      'yeah/this_is_sweet'.camelize.must_equal 'Yeah::ThisIsSweet'
+      _('this_is_sweet'.camelize).must_equal 'ThisIsSweet'
+      _('yeah/this_is_sweet'.camelize).must_equal 'Yeah::ThisIsSweet'
     end
 
     it 'changes CamelCase to under_score' do
-      'ThisIsSweet'.underscore.must_equal 'this_is_sweet'
-      'Yeah::ThisIsSweet'.underscore.must_equal 'yeah/this_is_sweet'
+      _('ThisIsSweet'.underscore).must_equal 'this_is_sweet'
+      _('Yeah::ThisIsSweet'.underscore).must_equal 'yeah/this_is_sweet'
     end
   end
 end

--- a/test/announce/test_message.rb
+++ b/test/announce/test_message.rb
@@ -7,24 +7,24 @@ describe Announce::Message do
 
   it 'can contruct with a hash' do
     msg = ::Announce::Message.new(subject: 'test', action: 'run', body: { foo: 'bar' } )
-    msg.wont_be_nil
-    msg.options.wont_be_nil
-    msg.options['subject'].must_equal 'test'
-    msg.options['action'].must_equal 'run'
+    _(msg).wont_be_nil
+    _(msg.options).wont_be_nil
+    _(msg.options['subject']).must_equal 'test'
+    _(msg.options['action']).must_equal 'run'
   end
 
   it 'can default options' do
-    announce_message.options['message_id'].wont_be_nil
-    announce_message.options['sent_at'].must_be_instance_of Time
-    announce_message.options['app'].must_equal 'app'
+    _(announce_message.options['message_id']).wont_be_nil
+    _(announce_message.options['sent_at']).must_be_instance_of Time
+    _(announce_message.options['app']).must_equal 'app'
   end
 
   it 'can serialize to json' do
     msg = JSON.parse(announce_message.to_json)
-    msg['app'].must_equal 'app'
+    _(msg['app']).must_equal 'app'
   end
 
   it 'can become a message hash' do
-    announce_message.to_message.must_be_instance_of Hash
+    _(announce_message.to_message).must_be_instance_of Hash
   end
 end

--- a/test/announce/test_message.rb
+++ b/test/announce/test_message.rb
@@ -1,30 +1,36 @@
-require 'test_helper'
-require 'announce/message'
+require "test_helper"
+require "announce/message"
 
 describe Announce::Message do
+  let (:announce_message) do
+    ::Announce::Message.new(
+      subject: "test", action: "run", body: { foo: "bar" }
+    )
+  end
 
-  let (:announce_message) { ::Announce::Message.new(subject: 'test', action: 'run', body: { foo: 'bar' } ) }
-
-  it 'can contruct with a hash' do
-    msg = ::Announce::Message.new(subject: 'test', action: 'run', body: { foo: 'bar' } )
+  it "can contruct with a hash" do
+    msg =
+      ::Announce::Message.new(
+        subject: "test", action: "run", body: { foo: "bar" }
+      )
     _(msg).wont_be_nil
     _(msg.options).wont_be_nil
-    _(msg.options['subject']).must_equal 'test'
-    _(msg.options['action']).must_equal 'run'
+    _(msg.options["subject"]).must_equal "test"
+    _(msg.options["action"]).must_equal "run"
   end
 
-  it 'can default options' do
-    _(announce_message.options['message_id']).wont_be_nil
-    _(announce_message.options['sent_at']).must_be_instance_of Time
-    _(announce_message.options['app']).must_equal 'app'
+  it "can default options" do
+    _(announce_message.options["message_id"]).wont_be_nil
+    _(announce_message.options["sent_at"]).must_be_instance_of Time
+    _(announce_message.options["app"]).must_equal "app"
   end
 
-  it 'can serialize to json' do
+  it "can serialize to json" do
     msg = JSON.parse(announce_message.to_json)
-    _(msg['app']).must_equal 'app'
+    _(msg["app"]).must_equal "app"
   end
 
-  it 'can become a message hash' do
+  it "can become a message hash" do
     _(announce_message.to_message).must_be_instance_of Hash
   end
 end

--- a/test/announce/test_publisher.rb
+++ b/test/announce/test_publisher.rb
@@ -1,21 +1,25 @@
-require 'test_helper'
-require 'json'
-require 'announce/publisher'
-require 'announce/message'
+require "test_helper"
+require "json"
+require "announce/publisher"
+require "announce/message"
 
 describe Announce::Publisher do
-  let (:publisher_class) { TestPublisher }
-  let (:publisher) { publisher_class.new }
+  let (:publisher_class) do
+    TestPublisher
+  end
+  let (:publisher) do
+    publisher_class.new
+  end
 
   before { clear_messages }
 
-  it 'can publish a message' do
-    publisher.publish('subject', 'action', { 'foo' => 'bar' }, {})
-    _(last_message['body']['foo']).must_equal 'bar'
+  it "can publish a message" do
+    publisher.publish("subject", "action", { "foo" => "bar" }, {})
+    _(last_message["body"]["foo"]).must_equal "bar"
   end
 
-  it 'can announce a message' do
-    publisher.announce('subject', 'action', { 'foo' => 'bar' }, {})
-    _(last_message['body']['foo']).must_equal 'bar'
+  it "can announce a message" do
+    publisher.announce("subject", "action", { "foo" => "bar" }, {})
+    _(last_message["body"]["foo"]).must_equal "bar"
   end
 end

--- a/test/announce/test_publisher.rb
+++ b/test/announce/test_publisher.rb
@@ -11,11 +11,11 @@ describe Announce::Publisher do
 
   it 'can publish a message' do
     publisher.publish('subject', 'action', { 'foo' => 'bar' }, {})
-    last_message['body']['foo'].must_equal 'bar'
+    _(last_message['body']['foo']).must_equal 'bar'
   end
 
   it 'can announce a message' do
     publisher.announce('subject', 'action', { 'foo' => 'bar' }, {})
-    last_message['body']['foo'].must_equal 'bar'
+    _(last_message['body']['foo']).must_equal 'bar'
   end
 end

--- a/test/announce/test_subscriber.rb
+++ b/test/announce/test_subscriber.rb
@@ -12,26 +12,26 @@ describe Announce::Subscriber do
   it 'can subscribe to subject and actions' do
     subscriber_class.subscribe_to('subject', ['create', 'delete'], { foo: 'bar' } )
     sub = last_subscription
-    sub[0].must_equal subscriber_class
-    sub[1].must_equal 'subject'
-    sub[2].must_equal ['create', 'delete']
-    sub[3][:foo].must_equal 'bar'
+    _(sub[0]).must_equal subscriber_class
+    _(sub[1]).must_equal 'subject'
+    _(sub[2]).must_equal ['create', 'delete']
+    _(sub[3][:foo]).must_equal 'bar'
   end
 
   it 'determines delegate method from message' do
-    subscriber.delegate_method(event_message).must_equal 'receive_subject_action'
+    _(subscriber.delegate_method(event_message)).must_equal 'receive_subject_action'
   end
 
   it 'calling delegate method save current message info' do
     subscriber.delegate_event(event_message)
-    subscriber.subject.must_equal 'subject'
-    subscriber.action.must_equal 'action'
-    subscriber.message.must_equal event_message
+    _(subscriber.subject).must_equal 'subject'
+    _(subscriber.action).must_equal 'action'
+    _(subscriber.message).must_equal event_message
   end
 
   it 'calling delegate method save current message info' do
     subscriber.delegate_event(event_message)
     em = subscriber_class.received.pop
-    em.must_equal event_message[:body]
+    _(em).must_equal event_message[:body]
   end
 end

--- a/test/announce/test_subscriber.rb
+++ b/test/announce/test_subscriber.rb
@@ -1,35 +1,42 @@
-require 'test_helper'
-require 'announce/subscriber'
+require "test_helper"
+require "announce/subscriber"
 
 describe Announce::Subscriber do
-
   before { clear_subscriptions }
 
-  let (:subscriber_class) { TestSubscriber }
-  let (:subscriber) { subscriber_class.new }
-  let (:event_message) { { subject: 'subject', action: 'action', body: { foo: 'bar' } } }
+  let (:subscriber_class) do
+    TestSubscriber
+  end
+  let (:subscriber) do
+    subscriber_class.new
+  end
+  let (:event_message) do
+    { subject: "subject", action: "action", body: { foo: "bar" } }
+  end
 
-  it 'can subscribe to subject and actions' do
-    subscriber_class.subscribe_to('subject', ['create', 'delete'], { foo: 'bar' } )
+  it "can subscribe to subject and actions" do
+    subscriber_class.subscribe_to("subject", %w[create delete], { foo: "bar" })
     sub = last_subscription
     _(sub[0]).must_equal subscriber_class
-    _(sub[1]).must_equal 'subject'
-    _(sub[2]).must_equal ['create', 'delete']
-    _(sub[3][:foo]).must_equal 'bar'
+    _(sub[1]).must_equal "subject"
+    _(sub[2]).must_equal %w[create delete]
+    _(sub[3][:foo]).must_equal "bar"
   end
 
-  it 'determines delegate method from message' do
-    _(subscriber.delegate_method(event_message)).must_equal 'receive_subject_action'
+  it "determines delegate method from message" do
+    _(
+      subscriber.delegate_method(event_message)
+    ).must_equal "receive_subject_action"
   end
 
-  it 'calling delegate method save current message info' do
+  it "calling delegate method save current message info" do
     subscriber.delegate_event(event_message)
-    _(subscriber.subject).must_equal 'subject'
-    _(subscriber.action).must_equal 'action'
+    _(subscriber.subject).must_equal "subject"
+    _(subscriber.action).must_equal "action"
     _(subscriber.message).must_equal event_message
   end
 
-  it 'calling delegate method save current message info' do
+  it "calling delegate method save current message info" do
     subscriber.delegate_event(event_message)
     em = subscriber_class.received.pop
     _(em).must_equal event_message[:body]

--- a/test/test_announce.rb
+++ b/test/test_announce.rb
@@ -6,53 +6,53 @@ describe Announce do
   after(:each) { reset_announce }
 
   it 'has a version number' do
-    Announce::VERSION.wont_be_nil
+    _(Announce::VERSION).wont_be_nil
   end
 
   it 'has options' do
-    Announce.options.wont_be_nil
-    Announce.options.must_be_instance_of Hash
+    _(Announce.options).wont_be_nil
+    _(Announce.options).must_be_instance_of Hash
   end
 
   it 'can configure options with hash and block' do
     Announce.configure() do |options|
-      options.wont_be_nil
+      _(options).wont_be_nil
       options[:foo] = 'bar'
     end
-    Announce.options[:foo].must_equal 'bar'
+    _(Announce.options[:foo]).must_equal 'bar'
   end
 
   it 'will call configure on the broker' do
-    Announce.configure_broker.must_equal true
+    _(Announce.configure_broker).must_equal true
   end
 
   it 'can publish a message' do
     Announce.publish('subject', 'action', 'body', {})
-    last_message['body'].must_equal 'body'
+    _(last_message['body']).must_equal 'body'
   end
 
   it 'can announce a message' do
     Announce.announce('subject', 'action', 'body', {})
-    last_message['body'].must_equal 'body'
+    _(last_message['body']).must_equal 'body'
   end
 
   it 'subscribes a worker' do
-    Announce.subscribe(self.class, 'subject', ['action']).must_equal true
+    _(Announce.subscribe(self.class, 'subject', ['action'])).must_equal true
   end
 
   it 'loads an adapter module' do
     adapter = Announce.adapter_class
-    adapter.must_equal Announce::Adapters::TestAdapter
+    _(adapter).must_equal Announce::Adapters::TestAdapter
   end
 
   it 'has a default logger' do
-    Announce.logger.wont_be_nil
-    Announce.logger.must_be_instance_of Logger
+    _(Announce.logger).wont_be_nil
+    _(Announce.logger).must_be_instance_of Logger
   end
 
   it 'can set the logger' do
     Announce.logger = 'foo'
-    Announce.logger.must_equal 'foo'
+    _(Announce.logger).must_equal 'foo'
     Announce.logger = Logger.new('/dev/null')
   end
 end

--- a/test/test_announce.rb
+++ b/test/test_announce.rb
@@ -1,58 +1,57 @@
-require 'test_helper'
+require "test_helper"
 
 describe Announce do
-
   before(:each) { reset_announce }
   after(:each) { reset_announce }
 
-  it 'has a version number' do
+  it "has a version number" do
     _(Announce::VERSION).wont_be_nil
   end
 
-  it 'has options' do
+  it "has options" do
     _(Announce.options).wont_be_nil
     _(Announce.options).must_be_instance_of Hash
   end
 
-  it 'can configure options with hash and block' do
-    Announce.configure() do |options|
+  it "can configure options with hash and block" do
+    Announce.configure do |options|
       _(options).wont_be_nil
-      options[:foo] = 'bar'
+      options[:foo] = "bar"
     end
-    _(Announce.options[:foo]).must_equal 'bar'
+    _(Announce.options[:foo]).must_equal "bar"
   end
 
-  it 'will call configure on the broker' do
+  it "will call configure on the broker" do
     _(Announce.configure_broker).must_equal true
   end
 
-  it 'can publish a message' do
-    Announce.publish('subject', 'action', 'body', {})
-    _(last_message['body']).must_equal 'body'
+  it "can publish a message" do
+    Announce.publish("subject", "action", "body", {})
+    _(last_message["body"]).must_equal "body"
   end
 
-  it 'can announce a message' do
-    Announce.announce('subject', 'action', 'body', {})
-    _(last_message['body']).must_equal 'body'
+  it "can announce a message" do
+    Announce.announce("subject", "action", "body", {})
+    _(last_message["body"]).must_equal "body"
   end
 
-  it 'subscribes a worker' do
-    _(Announce.subscribe(self.class, 'subject', ['action'])).must_equal true
+  it "subscribes a worker" do
+    _(Announce.subscribe(self.class, "subject", %w[action])).must_equal true
   end
 
-  it 'loads an adapter module' do
+  it "loads an adapter module" do
     adapter = Announce.adapter_class
     _(adapter).must_equal Announce::Adapters::TestAdapter
   end
 
-  it 'has a default logger' do
+  it "has a default logger" do
     _(Announce.logger).wont_be_nil
     _(Announce.logger).must_be_instance_of Logger
   end
 
-  it 'can set the logger' do
-    Announce.logger = 'foo'
-    _(Announce.logger).must_equal 'foo'
-    Announce.logger = Logger.new('/dev/null')
+  it "can set the logger" do
+    Announce.logger = "foo"
+    _(Announce.logger).must_equal "foo"
+    Announce.logger = Logger.new("/dev/null")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,6 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'announce'
 require 'announce/testing'
-# require 'announce/adapters/test_adapter'
 
 require 'minitest/autorun'
 require 'minitest/spec'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,34 +1,33 @@
-ENV['RAILS_ENV'] ||= 'test'
+ENV["RAILS_ENV"] ||= "test"
 
-require 'simplecov'
-SimpleCov.start 'rails'
+require "simplecov"
+SimpleCov.start "rails"
 
-if ENV['TRAVIS']
-  require 'coveralls'
+if ENV["TRAVIS"]
+  require "coveralls"
   Coveralls.wear!
 end
 
-ENV['APP_ENV'] = 'test'
-ENV['AWS_ACCESS_KEY_ID'] = 'ANDTHISISFAKEOKAY'
-ENV['AWS_SECRET_ACCESS_KEY'] = 'andthisisalsoveryfakesodontbefooledandtrytouseit'
-ENV['AWS_REGION'] = 'us-east-1'
-ENV['AWS_ACCOUNT_ID'] = '123456789012'
+ENV["APP_ENV"] = "test"
+ENV["AWS_ACCESS_KEY_ID"] = "ANDTHISISFAKEOKAY"
+ENV["AWS_SECRET_ACCESS_KEY"] = "thisisalsoveryfakesodontbefooledandtrytouseit"
+ENV["AWS_REGION"] = "us-east-1"
+ENV["AWS_ACCOUNT_ID"] = "123456789012"
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
-require 'announce'
-require 'announce/testing'
+require "announce"
+require "announce/testing"
 
-require 'minitest/autorun'
-require 'minitest/spec'
-require 'minitest/pride'
+require "minitest/autorun"
+require "minitest/spec"
+require "minitest/pride"
 
 class TestPublisher
   include Announce::Publisher
 end
 
 class TestSubscriber
-
   include Shoryuken::Worker
   include Announce::Subscriber
 


### PR DESCRIPTION
We're managing our infrastructure using CloudFormation, and only want the announce gem to indicate what resources are needed, not actually create them.

This new rake task and `verify_only: true` option will cause `announce` to log needed queues, topics, and subscriptions without actually connecting to AWS to try and create or update them.